### PR TITLE
Use the platform specific path separator (fix for Windows)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,7 +3,8 @@
 process.env.PWD = process.cwd();
 
 var yeoman = require('yeoman-generator'),
-	yosay = require('yosay');
+	yosay = require('yosay'),
+	path = require('path');
 
 var HexoThemeGenerator = yeoman.generators.Base.extend({
 	init: function() {
@@ -30,7 +31,7 @@ var HexoThemeGenerator = yeoman.generators.Base.extend({
 			{
 				name: 'themename',
 				message: 'What is your theme name?',
-				default: process.env.PWD.split('/').pop()
+				default: process.env.PWD.split(path.sep).pop()
 			},
 			{
 				name: 'templatelang',


### PR DESCRIPTION
First of all, great generator :+1:! 

I've noticed that when running the generator on Windows, the default theme name contains the full path to the folder where the theme is located and not just the last folder.

``` bash
Cristi@home /d/Work/Temp/hexo-test/blog/themes/test-theme
$ yo hexo-theme

     _-----_
    |       |    .--------------------------.
    |--(o)--|    | Welcome to the marvelous |
   `---------´   |   Hexo theme generator!  |
    ( _´U`_ )    '--------------------------'
    /___A___\
     |  ~  |
   __'.___.'__
 ´   `  |° ´ Y `

? What is your theme name? /d/Work/Temp/hexo-test/blog/themes/test-theme
```

For the fix, I've updated the code to use the value from path.sep as the path separator, instead of "/". This should work on all OS flavors supported by node.js.